### PR TITLE
various constructing bean improvement

### DIFF
--- a/config/src/main/java/com/typesafe/config/impl/ConfigBeanImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigBeanImpl.java
@@ -335,9 +335,14 @@ public class ConfigBeanImpl {
 
     private static boolean hasPropertiesBindedToConstructor(Class<?> clazz) {
         for (Constructor<?> constructor : clazz.getConstructors()) {
-            ConstructorProperties annotation = constructor.getAnnotation(ConstructorProperties.class);
-            if (annotation != null) {
-                return true;
+            if ((constructor.getModifiers() & Modifier.PUBLIC) != 0) {
+                ConstructorProperties annotation = constructor.getAnnotation(ConstructorProperties.class);
+                if (annotation != null) {
+                    return true;
+                }
+                if (constructor.getParameterCount() > 0 && constructor.getParameters()[0].isNamePresent()) {
+                    return true;
+                }
             }
         }
         return false;

--- a/config/src/main/java/com/typesafe/config/impl/ConfigBeanImpl.java
+++ b/config/src/main/java/com/typesafe/config/impl/ConfigBeanImpl.java
@@ -9,10 +9,12 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -156,7 +158,7 @@ public class ConfigBeanImpl {
             }
 
             // Create and fill the bean instance
-            T bean = classConstructor.constructor.newInstance(constructorArgs);
+            T bean = classConstructor.construct(constructorArgs);
             for (PropertyDescriptor beanProp : beanProps) {
                 Method setter = beanProp.getWriteMethod();
                 Type parameterType = setter.getGenericParameterTypes()[0];
@@ -175,8 +177,6 @@ public class ConfigBeanImpl {
                 setter.invoke(bean, unwrapped);
             }
             return bean;
-        } catch (InstantiationException e) {
-            throw new ConfigException.BadBean(clazz.getName() + " needs a public no-args constructor to be used as a bean", e);
         } catch (IllegalAccessException e) {
             throw new ConfigException.BadBean(clazz.getName() + " getters and setters are not accessible, they must be for use as a bean", e);
         } catch (InvocationTargetException e) {
@@ -368,30 +368,50 @@ public class ConfigBeanImpl {
     }
 
     private static <T> ConstructorInfo<T> getConstructor(Class beanClass) {
-        List<ConstructorInfo<T>> classConstructors = new ArrayList<ConstructorInfo<T>>();
+        ConstructorInfo<T> targetConstructor = null;
+        Constructor<T> firstPublicConstructor = null;
+        boolean single = true;
         for (Constructor<?> constructor : beanClass.getConstructors()) {
-            ConstructorProperties annotation = constructor.getAnnotation(ConstructorProperties.class);
-            if (annotation != null) {
-                classConstructors.add(new ConstructorInfo<T>((Constructor<T>)constructor, annotation.value()));
+            if ((constructor.getModifiers() & Modifier.PUBLIC) != 0) {
+                ConstructorProperties annotation = constructor.getAnnotation(ConstructorProperties.class);
+                if (annotation != null) {
+                    if (targetConstructor == null) {
+                        targetConstructor = new ConstructorInfo<T>((Constructor<T>)constructor, annotation.value());
+                    } else {
+                        throw new ConfigException.BadBean(beanClass.getName() + " needs a single public constructor marked with @ConstructorProperties to be used as a bean");
+                    }
+                }
+                if (firstPublicConstructor == null) {
+                    firstPublicConstructor = (Constructor<T>) constructor;
+                } else {
+                    single = false;
+                }
             }
         }
-        ConstructorInfo<T> targetConstructor;
-        if (classConstructors.size() > 1) {
-            throw new ConfigException.BadBean(beanClass.getName() + " needs a single constructor marked with @ConstructorProperties to be used as a bean");
-        } else if (classConstructors.isEmpty()) {
+        if (targetConstructor == null && single && firstPublicConstructor.getParameterCount() > 0) {
+            //If there is only one public constructor with parameters and bean is compiled with `-parameters` argument, try to use it
+            List<String> parameters = new ArrayList<>();
+            for (Parameter parameter : firstPublicConstructor.getParameters()) {
+                if (parameter.isNamePresent()) {
+                    parameters.add(parameter.getName());
+                } else {
+                    throw new ConfigException.BadBean(beanClass.getName() + " needs a single public constructor marked with @ConstructorProperties to be used as a bean");
+                }
+            }
+            targetConstructor = new ConstructorInfo<>(firstPublicConstructor, parameters.toArray(ConstructorInfo.EMPTY_ARRAY));
+        } else if (targetConstructor == null) {
             try {
                 //If there are no constructors marked with @ConstructorProperties, try to use default class constructor
-                targetConstructor = new ConstructorInfo<>((Constructor<T>)beanClass.getConstructor(), new String[]{});
+                targetConstructor = new ConstructorInfo<>((Constructor<T>)beanClass.getConstructor(), ConstructorInfo.EMPTY_ARRAY);
             } catch (NoSuchMethodException e) {
                 throw new ConfigException.BadBean(beanClass.getName() + " needs a public no-args constructor to be used as a bean", e);
             }
-        } else {
-            targetConstructor = classConstructors.get(0);
         }
         return targetConstructor;
     }
 
     private static class ConstructorInfo<T> {
+        static final String[] EMPTY_ARRAY = new String[]{};
         private final Constructor<T> constructor;
         private final String[] parameterNames;
 
@@ -410,6 +430,22 @@ public class ConfigBeanImpl {
 
         int getParamsCount() {
             return constructor.getParameterCount();
+        }
+
+        T construct(Object[] constructorArgs) throws InvocationTargetException {
+            try {
+                return constructor.newInstance(constructorArgs);
+            } catch (InstantiationException e) {
+                throw new ConfigException.BadBean(constructor.getClass().getName() + " must not be an abstract class to be used as a bean", e);
+            } catch (IllegalAccessException e) {
+                if (constructorArgs.length == 0) {
+                    throw new ConfigException.BadBean(constructor.getClass().getName() + " needs a public no-args constructor to be used as a bean");
+                } else {
+                    throw new ConfigException.BadBean(constructor.getClass().getName() + " needs a public constructor with parameters types " + Arrays.toString(constructor.getParameterTypes()) + " to be used as a bean");
+                }
+            } catch (IllegalArgumentException e) {
+                throw new ConfigException.BugOrBroken("Bean " + constructor.getClass().getName() + " constructor invocation failed due to parameters mismatch: " + e.getMessage(), e);
+            }
         }
     }
 }

--- a/config/src/test/java/beanconfig/ConstructorConfig.java
+++ b/config/src/test/java/beanconfig/ConstructorConfig.java
@@ -67,4 +67,23 @@ public class ConstructorConfig {
       return foo;
     }
   }
+
+  public static class ConstructorConfigSkipWithoutAnnotation extends ConstructorConfig {
+
+    @ConstructorProperties({"foo", "bar", "nested", "nestedWithoutAnnotation"})
+    public ConstructorConfigSkipWithoutAnnotation(String foo, @Optional String bar, NestedConfig nested, NestedWithAnnotation nestedWithAnnotation) {
+        super(foo, bar, nested, nestedWithAnnotation);
+    }
+
+  }
+
+  public static class NestedWithAnnotation extends NestedWithoutAnnotation {
+
+      @ConstructorProperties({"foo"})
+      public NestedWithAnnotation(String foo) {
+        super(foo);
+      }
+
+    }
+
 }

--- a/config/src/test/java/beanconfig/ConstructorConfig.java
+++ b/config/src/test/java/beanconfig/ConstructorConfig.java
@@ -8,13 +8,15 @@ public class ConstructorConfig {
   private final String foo;
   private final String bar;
   private final NestedConfig nested;
+  private final NestedWithoutAnnotation nestedWithoutAnnotation;
   private String baz;
 
-  @ConstructorProperties({"foo", "bar", "nested"})
-  public ConstructorConfig(String foo, @Optional String bar, NestedConfig nested) {
+  @ConstructorProperties({"foo", "bar", "nested", "nestedWithoutAnnotation"})
+  public ConstructorConfig(String foo, @Optional String bar, NestedConfig nested, NestedWithoutAnnotation nestedWithoutAnnotation) {
     this.foo = foo;
     this.bar = bar;
     this.nested = nested;
+    this.nestedWithoutAnnotation = nestedWithoutAnnotation;
   }
 
   public String getFoo() {
@@ -27,6 +29,10 @@ public class ConstructorConfig {
 
   public NestedConfig getNested() {
     return nested;
+  }
+
+  public NestedWithoutAnnotation getNestedWithoutAnnotation() {
+    return nestedWithoutAnnotation;
   }
 
   public String getBaz() {
@@ -42,6 +48,18 @@ public class ConstructorConfig {
 
     @ConstructorProperties({"foo"})
     public NestedConfig(String foo) {
+      this.foo = foo;
+    }
+
+    public String getFoo() {
+      return foo;
+    }
+  }
+
+  public static class NestedWithoutAnnotation {
+    private final String foo;
+
+    public NestedWithoutAnnotation(String foo) {
       this.foo = foo;
     }
 

--- a/config/src/test/java/beanconfig/ConstructorConfigNoAnnotation.java
+++ b/config/src/test/java/beanconfig/ConstructorConfigNoAnnotation.java
@@ -1,0 +1,37 @@
+package beanconfig;
+
+import com.typesafe.config.Optional;
+
+public class ConstructorConfigNoAnnotation {
+  private final String foo;
+  private final String bar;
+  private final ConstructorConfig.NestedConfig nested;
+  private String baz;
+
+  public ConstructorConfigNoAnnotation(String foo, @Optional String bar, ConstructorConfig.NestedConfig nested) {
+    this.foo = foo;
+    this.bar = bar;
+    this.nested = nested;
+  }
+
+  public String getFoo() {
+    return foo;
+  }
+
+  public String getBar() {
+    return bar;
+  }
+
+  public ConstructorConfig.NestedConfig getNested() {
+    return nested;
+  }
+
+  public String getBaz() {
+    return baz;
+  }
+
+  public void setBaz(String baz) {
+    this.baz = baz;
+  }
+
+}

--- a/config/src/test/resources/beanconfig/beanconfig01.conf
+++ b/config/src/test/resources/beanconfig/beanconfig01.conf
@@ -133,6 +133,9 @@
     "nested": {
       "foo": "nestedFooString"
     },
+    "nestedWithoutAnnotation": {
+      "foo": "nestedFooString"
+    },
     "baz": "bazString"
   }
 }

--- a/config/src/test/resources/beanconfig/beanconfig01.conf
+++ b/config/src/test/resources/beanconfig/beanconfig01.conf
@@ -134,7 +134,7 @@
       "foo": "nestedFooString"
     },
     "nestedWithoutAnnotation": {
-      "foo": "nestedFooString"
+      "foo": "nestedWithoutAnnotationString"
     },
     "baz": "bazString"
   }

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
@@ -9,6 +9,7 @@ import java.io.{ InputStream, InputStreamReader }
 import java.time.Duration
 
 import beanconfig.ConstructorConfig.NestedConfig
+import beanconfig.ConstructorConfig.ConstructorConfigSkipWithoutAnnotation
 import beanconfig._
 import org.junit.Assert._
 import org.junit._
@@ -281,7 +282,8 @@ class ConfigBeanFactoryTest extends TestUtils {
 
     @Test
     def testConstructor(): Unit = {
-        val bean = ConfigBeanFactory.create(loadConfig().getConfig("constructor"), classOf[ConstructorConfig])
+        val cls = compiledWithNames() ? classOf[ConstructorConfig] : classOf[ConstructorConfigSkipWithoutAnnotation]
+        val bean = ConfigBeanFactory.create(loadConfig().getConfig("constructor"), cls)
         val nestedBean = bean.getNested
         val nestedNoAnnotation = bean.getNestedWithoutAnnotation
 
@@ -303,9 +305,7 @@ class ConfigBeanFactoryTest extends TestUtils {
 
     @Test
     def testNoAnnotationSingleConstructor(): Unit = {
-        val names = classOf[ConstructorConfigNoAnnotation].getConstructor(classOf[String], classOf[String], classOf[NestedConfig]).getParameters()(0).isNamePresent
-
-        if (names) {
+        if (compiledWithNames()) {
             val bean = ConfigBeanFactory.create(loadConfig().getConfig("constructor"), classOf[ConstructorConfigNoAnnotation])
             val nestedBean = bean.getNested
 
@@ -320,6 +320,10 @@ class ConfigBeanFactoryTest extends TestUtils {
             }
             assertTrue("no constructor", e.getMessage.contains("needs a single public constructor"))
         }
+    }
+
+    private def compiledWithNames(): boolean = {
+        classOf[ConstructorConfigNoAnnotation].getConstructor(classOf[String], classOf[String], classOf[NestedConfig]).getParameters()(0).isNamePresent
     }
 
     private def loadConfig(): Config = {

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
@@ -295,7 +295,28 @@ class ConfigBeanFactoryTest extends TestUtils {
         val e = intercept[ConfigException.BadBean] {
             ConfigBeanFactory.create(ConfigFactory.empty(), classOf[MultipleConstructorsConfig])
         }
-        assertTrue("multiple constructors", e.getMessage.contains("needs a single constructor"))
+        assertTrue("multiple constructors", e.getMessage.contains("needs a single public constructor"))
+    }
+
+    @Test
+    def testNoAnnotationSingleConstructor(): Unit = {
+        val names = classOf[ConstructorConfigNoAnnotation].getConstructor(classOf[String], classOf[String], classOf[NestedConfig]).getParameters()[0].isNamePresent();
+
+        if (names) {
+            val bean = ConfigBeanFactory.create(loadConfig().getConfig("constructor"), classOf[ConstructorConfigNoAnnotation])
+            val nestedBean = bean.getNested
+
+            assertEquals("foo", "fooString", bean.getFoo)
+            assertNull("bar", bean.getBar)
+            assertNotNull("nested", nestedBean)
+            assertEquals("nestedFooString", nestedBean.getFoo)
+            assertEquals("baz", "bazString", bean.getBaz)
+        } else {
+            val e = intercept[ConfigException.BadBean] {
+                ConfigBeanFactory.create(ConfigFactory.empty(), classOf[ConstructorConfigNoAnnotation])
+            }
+            assertTrue("no constructor", e.getMessage.contains("needs a single public constructor"))
+        }
     }
 
     private def loadConfig(): Config = {

--- a/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
+++ b/config/src/test/scala/com/typesafe/config/impl/ConfigBeanFactoryTest.scala
@@ -3,11 +3,12 @@
  */
 package com.typesafe.config.impl
 
-import beanconfig.EnumsConfig.{Problem, Solution}
-import com.typesafe.config.{ConfigBeanFactory, _}
-import java.io.{InputStream, InputStreamReader}
+import beanconfig.EnumsConfig.{ Problem, Solution }
+import com.typesafe.config.{ ConfigBeanFactory, _ }
+import java.io.{ InputStream, InputStreamReader }
 import java.time.Duration
 
+import beanconfig.ConstructorConfig.NestedConfig
 import beanconfig._
 import org.junit.Assert._
 import org.junit._
@@ -282,12 +283,14 @@ class ConfigBeanFactoryTest extends TestUtils {
     def testConstructor(): Unit = {
         val bean = ConfigBeanFactory.create(loadConfig().getConfig("constructor"), classOf[ConstructorConfig])
         val nestedBean = bean.getNested
+        val nestedNoAnnotation = bean.getNestedWithoutAnnotation
 
         assertEquals("foo", "fooString", bean.getFoo)
         assertNull("bar", bean.getBar)
         assertNotNull("nested", nestedBean)
         assertEquals("nestedFooString", nestedBean.getFoo)
         assertEquals("baz", "bazString", bean.getBaz)
+        assertEquals("nestedWithoutAnnotationString", nestedNoAnnotation.getFoo)
     }
 
     @Test
@@ -300,7 +303,7 @@ class ConfigBeanFactoryTest extends TestUtils {
 
     @Test
     def testNoAnnotationSingleConstructor(): Unit = {
-        val names = classOf[ConstructorConfigNoAnnotation].getConstructor(classOf[String], classOf[String], classOf[NestedConfig]).getParameters()[0].isNamePresent();
+        val names = classOf[ConstructorConfigNoAnnotation].getConstructor(classOf[String], classOf[String], classOf[NestedConfig]).getParameters()(0).isNamePresent
 
         if (names) {
             val bean = ConfigBeanFactory.create(loadConfig().getConfig("constructor"), classOf[ConstructorConfigNoAnnotation])


### PR DESCRIPTION
Please consider including this PR to your PR for lightbend/config. It includes:
* public check during constructor discovery
* more accurate exception handling
* support for single constructor compiled with `-parameters`

Sorry, didn't managed to setup sbt, so I've added new test in java and translated it to scala by hand. It could contain errors.